### PR TITLE
Fix problem that field symbol definitions are not visible

### DIFF
--- a/exercises/ex01/README.md
+++ b/exercises/ex01/README.md
@@ -86,7 +86,7 @@ First you will create an ABAP package, a database table, and an ABAP class to fi
  
       > **Hint**: Hover the code snippet and choose the _Copy raw contents_ icon <img src="images/copyrawcontents.png" alt="table" width="30px"> appearing in the upper-right corner to copy it. 
       
-      <pre lang="ABAP">
+      ```ABAP
       @EndUserText.label : 'Travel data'
       @AbapCatalog.enhancement.category : #NOT_EXTENSIBLE
       @AbapCatalog.tableCategory : #TRANSPARENT
@@ -115,7 +115,7 @@ First you will create an ABAP package, a database table, and an ABAP class to fi
         local_last_changed_at : abp_locinst_lastchange_tstmpl;
         last_changed_at       : abp_lastchange_tstmpl; 
       }
-      </pre>
+      ```
  
       <img src="images/Picture22x.png" alt="table" width="60%">
       
@@ -401,7 +401,7 @@ Below is a brief explanation of the generated artefacts for the different RAP la
 
       The field **attachment** is a raw string (data type `RAWSTRING`) and cannot be used in the filter bar, so the annotation **`@UI.selectionField`** is not allowed for this field and should be removed. Therefore, remove following annotation block for the field attachment:
 
-      ```ABAP
+      ```ABAP-CDS
       @UI.selectionField: [ {
           position: 10 
         } ]

--- a/exercises/ex02/README.md
+++ b/exercises/ex02/README.md
@@ -44,7 +44,7 @@ The enablement of OData streams will give end-users the option to upload and dow
  
     Insert the following code snippet after the **`select`** statement as shown on the screenshot below and format the source code (**Shift+F1**).            
      
-    ```ABAP
+    ```ABAP-CDS
     association [0..1] to /DMO/I_Agency            as _Agency        on $projection.AgencyID = _Agency.AgencyID
     association [0..1] to /DMO/I_Customer          as _Customer      on $projection.CustomerID = _Customer.CustomerID
     association [1..1] to /DMO/I_Overall_Status_VH as _OverallStatus on $projection.OverallStatus = _OverallStatus.OverallStatus
@@ -59,7 +59,7 @@ The enablement of OData streams will give end-users the option to upload and dow
   
      For that, insert the code snippet provided below in the selection list between the curly brackets (`{...}`) as shown on the screenshot and format the source code (**Shift+F1**).
 
-     ```ABAP
+     ```ABAP-CDS
      ,
  
      //public associations
@@ -98,12 +98,12 @@ The enablement of OData streams will give end-users the option to upload and dow
  2. Use the code snippets provided below and annotate the elements as shown on the screenshot.
 
      - For element **`MimeType`**: 
-     ```ABAP
+     ```ABAP-CDS
         @Semantics.mimeType: true
      ```
 
      - For element **`Attachment`**:
-     ```ABAP
+     ```ABAP-CDS
        @Semantics.largeObject: { mimeType: 'MimeType',   //case-sensitive
                                  fileName: 'FileName',   //case-sensitive
                                  acceptableMimeTypes: ['image/png', 'image/jpeg'],
@@ -135,7 +135,7 @@ The enablement of OData streams will give end-users the option to upload and dow
  1. Open your data definition ![datadefinition](images/adt_ddls.png)**`ZRAP100_C_TRAVELTP_###`** and format the generated source code with the **Pretty Printer** (**Shift+F1**)..
     
     Specify the projection view as searchable by adding the following view annotation as shown on the screenshot below:  
-    ```ABAP
+    ```ABAP-CDS
      @Search.searchable: true
     ```
  
@@ -143,7 +143,7 @@ The enablement of OData streams will give end-users the option to upload and dow
     > In the generated data definition, the element `TravelID` is specified as the semantic key of the _Travel_ entity with the view annotation `@ObjectModel.semanticKey: ['TravelID']` and the CDS projection view is specified as BO projections with the addition `provider contract transactional_query` in the `DEFINE ROOT VIEW ENTITY` statement.  
  
     Replace the end-user label text:  
-    ```ABAP
+    ```ABAP-CDS
      @EndUserText.label: '##GENERATED Travel App (###)'
     ```
  
@@ -159,16 +159,16 @@ The enablement of OData streams will give end-users the option to upload and dow
     For that, add the appropriate code snippets as shown on the screenshot below:
  
     - Define `AgencyName` after `AgencyID`:
-       ```ABAP
+       ```ABAP-CDS
          _Agency.Name              as AgencyName,
        ```
     - Define `CustomerName` after `CustomerID`:
-       ```ABAP
+       ```ABAP-CDS
          _Customer.LastName        as CustomerName,
        ```  
  
     - Define `OverallStatusText` after `OverallStatus`:    
-       ```ABAP
+       ```ABAP-CDS
          _OverallStatus._Text.Text as OverallStatusText : localized,
        ```  
       > Note: The keyword `localized` is used to display text elements in the current system language.
@@ -182,14 +182,14 @@ The enablement of OData streams will give end-users the option to upload and dow
      
     - For the element **`TravelID`**: Enable the full-text search with a specific fuzziness (error tolerance).    
 
-       ```ABAP
+       ```ABAP-CDS
        @Search.defaultSearchElement: true
        @Search.fuzzinessThreshold: 0.90    
        ```
      
     - For element **`AgencyID`**: Enable the full-text search, define a value help, and specified **`AgencyName`** as associated text. The defined value help shall be automatically used for frontend validations in Fiori elements UIs.
 
-       ```ABAP
+       ```ABAP-CDS
        @Search.defaultSearchElement: true
        @ObjectModel.text.element: ['AgencyName']
        @Consumption.valueHelpDefinition: [{ entity : {name: '/DMO/I_Agency_StdVH', element: 'AgencyID' }, useForValidation: true }] 
@@ -197,7 +197,7 @@ The enablement of OData streams will give end-users the option to upload and dow
      
     - For element **`CustomerID`**: Enable the full-text search, specify **`CustomerName`** as associated text, and define a value help which will automatically be used for frontend validations in Fiori elements UIs.
  
-       ```ABAP
+       ```ABAP-CDS
        @Search.defaultSearchElement: true
        @ObjectModel.text.element: ['CustomerName']
        @Consumption.valueHelpDefinition: [{ entity : {name: '/DMO/I_Customer_StdVH', element: 'CustomerID' }, useForValidation: true }]
@@ -205,13 +205,13 @@ The enablement of OData streams will give end-users the option to upload and dow
     
     - For  element **`CurrencyCode`**: Define a value help which will automatically be used for validations in Fiori elements UIs.
 
-       ```ABAP
+       ```ABAP-CDS
        @Consumption.valueHelpDefinition: [{ entity: {name: 'I_CurrencyStdVH', element: 'Currency' }, useForValidation: true }]
        ```
      
     - For element **`OverallStatus`**: Specify **`OverallStatusText`** as associated text and define a value help which will automatically be used for frontend validations in Fiori elements UIs.
 
-       ```ABAP
+       ```ABAP-CDS
        @ObjectModel.text.element: ['OverallStatusText']
        @Consumption.valueHelpDefinition: [{ entity: {name: '/DMO/I_Overall_Status_VH', element: 'OverallStatus' }, useForValidation: true }]
        ```

--- a/exercises/ex05/README.md
+++ b/exercises/ex05/README.md
@@ -43,12 +43,12 @@ A validation is implicitly invoked by the business object’s framework if the t
 2. Because empty values will not be accepted for the fields **`CustomerID`**, **`BeginDate`**, and **`EndDate`**, specify them as _mandatory_ field 
    by adding the following code snippet after the determination as shown on the screenshot below.
  
-   <pre lang="ABAP">  
+   ```ABAP
     field ( mandatory )
     CustomerID,
     BeginDate,
     EndDate;  
-   </pre>   
+   ```
 
    Your source code should look like this:   
 
@@ -59,21 +59,21 @@ A validation is implicitly invoked by the business object’s framework if the t
      
    For that, add the following code snippet after the determination as shown on the screenshot below.
    
-   <pre lang="ABAP"> 
+   ```ABAP 
    validation validateCustomer on save { create; field CustomerID; }
    validation validateDates on save { create; field BeginDate, EndDate; }
-   </pre>          
+   ```          
 
 4. In order to have draft instances being checked by validations and determinations being executed before they become active, they have to be specified for the **`draft determine action prepare`** in the behavior definition.
   
    Replace the code line **`draft determine action Prepare;`** with the following code snippet as shown on the screenshot below
 
-   <pre lang="ABAP"> 
+   ```ABAP 
    draft determine action Prepare
    {
    validation validateCustomer;
    validation validateDates;    }
-   </pre>     
+   ```     
      
    Your source code should look like this: 
    

--- a/exercises/ex06/README.md
+++ b/exercises/ex06/README.md
@@ -153,7 +153,7 @@ As *optional* exercises, you can additionally implement the two non-factory, ins
    You can use the **ABAP Pretty Printer** (**Ctrl+F1**) to format your source code.
 
 
-   <pre lang="ABAP">  
+   ```ABAP  
    **************************************************************************
    * Instance-bound non-factory action:
    * Deduct the specified discount from the booking fee (BookingFee)
@@ -194,7 +194,7 @@ As *optional* exercises, you can additionally implement the two non-factory, ins
      result = VALUE #( FOR travel IN travels_with_discount ( %tky   = travel-%tky
                                                                %param = travel ) ).
    ENDMETHOD.
-   </pre>
+   ```
 
    The result should look like this:
 
@@ -242,7 +242,7 @@ As *optional* exercises, you can additionally implement the two non-factory, ins
    
    **Please note**: Some lines in the provided code snippet are commented out using **`//`** at the beginning. **DO NOT remove them**. You will uncomment these lines in the following exercise steps.
       
-   <pre lang="ABAP CDS">
+   ```ABAP-CDS
      @UI: {
          lineItem:       [ { position: 100, importance: #HIGH }                          
                            //,{ type: #FOR_ACTION, dataAction: 'copyTravel', label: 'Copy Travel' } 
@@ -256,7 +256,7 @@ As *optional* exercises, you can additionally implement the two non-factory, ins
               ],
            textArrangement: #TEXT_ONLY
          }
-   </pre>
+   ```
 
    The result should look like this:
    
@@ -342,7 +342,7 @@ As *optional* exercises, you can additionally implement the two non-factory, ins
    
    You can use the **ABAP Pretty Printer** (**Ctrl+F1**) to format your source code.
       
-   <pre lang="ABAP">
+   ```ABAP
    **************************************************************************
    * Instance-bound non-factory action with parameter `deductDiscount`:
    * Deduct the specified discount from the booking fee (BookingFee)
@@ -408,7 +408,7 @@ As *optional* exercises, you can additionally implement the two non-factory, ins
       result = VALUE #( FOR travel IN travels_with_discount ( %tky   = travel-%tky
                                                               %param = travel ) ).
     ENDMETHOD.
-   </pre>
+   ```
    
    The result should look like this:
    
@@ -517,7 +517,7 @@ As *optional* exercises, you can additionally implement the two non-factory, ins
    
    For that, replace the current method implementation with the code snippet provided below and replace all occurrences of the placeholder **`###`** with your group ID.   
    
-   <pre lang="ABAP">
+   ```ABAP
    **************************************************************************
    * Instance-bound factory action `copyTravel`:
    * Copy an existing travel instance
@@ -565,7 +565,7 @@ As *optional* exercises, you can additionally implement the two non-factory, ins
        " set the new BO instances
        mapped-travel   =  mapped_create-travel .
      ENDMETHOD.              
-   </pre>
+   ```
    
    Your source code should like this:
    
@@ -699,7 +699,7 @@ You are through with the definition of both actions. Go ahead with the implement
  
    For that, replace the current method implementation with the code snippet provided below and replace all occurrences of the placeholder **`###`** with your group ID. You can make use of the **F1 Help** for more information about the EML statements and other ABAP constructs.
    
-   <pre lang="ABAP">
+   ```ABAP
    *************************************************************************************
    * Instance-bound non-factory action: Set the overall travel status to 'A' (accepted)
    *************************************************************************************
@@ -724,7 +724,7 @@ You are through with the definition of both actions. Go ahead with the implement
        result = VALUE #( FOR travel IN travels ( %tky   = travel-%tky
                                                  %param = travel ) ).
      ENDMETHOD.
-   </pre>
+   ```
    
    Your source code should look like this:
    
@@ -740,7 +740,7 @@ You are through with the definition of both actions. Go ahead with the implement
    
    For that, replace the current method implementation with the code snippet provided below and replace all occurrences of the placeholder **`###`** with your group ID.
 
-   <pre lang="ABAP">   
+   ```ABAP   
    *************************************************************************************
    * Instance-bound non-factory action: Set the overall travel status to 'X' (rejected)
    *************************************************************************************
@@ -765,7 +765,7 @@ You are through with the definition of both actions. Go ahead with the implement
        result = VALUE #( FOR travel IN travels ( %tky   = travel-%tky
                                                  %param = travel ) ).
      ENDMETHOD.   
-   </pre>
+   ```
    
    Your source code should look like this:
    

--- a/exercises/ex09/README.md
+++ b/exercises/ex09/README.md
@@ -438,7 +438,9 @@ As suggested by the title: Play around with EML!
 For examples,
 - Copy the methods of your choice and adjust them as you like.  
 - Execute all operations: For that, set the variable **`execute`** to **`55`** and specify the required values (**`travel_id`** and **`instance_state`**) for the different operations.    
-  <pre> DATA(execute) = 55. </pre>
+  ```ABAP
+    DATA(execute) = 55.
+  ```
    
 Feel free to ask questions.
 


### PR DESCRIPTION
They are treated as HTML tags when inside of \<pre>. Changing the syntax highlighting to triple ticks. Making syntax highlighting consistent, ABAP vs ABAP-CDS.

Example:
[Exercise 6.1.2: Implement the Action Method
](https://github.com/SAP-samples/abap-platform-rap100/tree/main/exercises/ex06#exercise-612-implement-the-action-method)
Field symbol definition shows up as:
```ABAP
LOOP AT travels ASSIGNING FIELD-SYMBOL().  
      DATA(reduced_fee) = -BookingFee * ( 1 - 3 / 10 ) .  

      APPEND VALUE #( %tky       = -%tky
                    BookingFee = reduced_fee
                  ) TO travels_for_update.
ENDLOOP.
```